### PR TITLE
May the source be with you

### DIFF
--- a/calysto_hy/kernel.py
+++ b/calysto_hy/kernel.py
@@ -116,16 +116,6 @@ class CalystoHy(MetaKernel):
         return matches
 
 
-def extend_matches(matches, txt, completions):
-    for p in completions:
-        p = filter(lambda x: isinstance(x, str), p.keys())
-        p = [x.replace('_', '-') for x in p]
-        matches.extend([
-            x for x in p
-            if x.startswith(txt) and x not in matches
-        ])
-
-
 def latex_matches(text):
     """
     Match Latex syntax for unicode characters.

--- a/calysto_hy/kernel.py
+++ b/calysto_hy/kernel.py
@@ -19,6 +19,8 @@ from .version import __version__
 
 from metakernel import MetaKernel
 
+from jedhy import Actions
+
 try:
     from IPython.core.latex_symbols import latex_symbols
 except:
@@ -107,15 +109,22 @@ class CalystoHy(MetaKernel):
         matches = latex_matches(txt)
         if matches:
             return matches
-        matches = [word for word in self.env if word.startswith(txt)]
-        for p in list(_hy_macros.values()) + [_compile_table]:
-            p = filter(lambda x: isinstance(x, str), p.keys())
-            p = [x.replace('_', '-') for x in p]
-            matches.extend([
-                x for x in p
-                if x.startswith(txt) and x not in matches
-            ])
+
+        jedhy = Actions(globals_=self.env)
+        matches = jedhy.complete(txt)
+
         return matches
+
+
+def extend_matches(matches, txt, completions):
+    for p in completions:
+        p = filter(lambda x: isinstance(x, str), p.keys())
+        p = [x.replace('_', '-') for x in p]
+        matches.extend([
+            x for x in p
+            if x.startswith(txt) and x not in matches
+        ])
+
 
 def latex_matches(text):
     """

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,12 @@ setup(name='calysto_hy',
       author_email='doug.blank@gmail.com',
       url="https://github.com/Calysto/calysto_hy",
       install_requires=["metakernel", "hy"],
+      dependency_links=[
+          "git+https://github.com/ekaschalk/jedhy.git"
+      ],
       packages=find_packages(include=["calysto_hy", "calysto_hy.*"]),
       package_data={'calysto_hy': ["images/*.png", "modules/*.ss"]},
-      classifiers = [
+      classifiers=[
           'Framework :: IPython',
           'License :: OSI Approved :: BSD License',
           'Programming Language :: Python :: 3',


### PR DESCRIPTION
This addresses my request #8 

The completion works like a charm. 
And ... before merging here are my observations.

1. jedhy uses hy master ... no released or tagged version. That's not an issue with me as I'm using bleding edge anyway with hy. I would either have to backport and fix to hy 0.13.1, basically it's just the use of deftag vs. defsharp I think
2. jedhy has no pypi release and also uses toolz, which is not listed as dependency. which leads me to  ...
3. using setuptools installing from git doesn't work. I added the dependency_link in the setup.py but it doesn't work.

Backport or bleeding edge?
If so the README has to be modified to in order to give the proper setup instructions. which is:

```bash
pip install git+https://github.com/hylang/hy.git
pip install git+https://github.com/ekaschalk/jedhy.git
pip install toolz
pip install calysto_hy
```