### PR TITLE
Fix macro loading on Hy 0.18.0

### DIFF
--- a/calysto_hy/kernel.py
+++ b/calysto_hy/kernel.py
@@ -8,6 +8,7 @@ import __future__  # NOQA
 import ast
 import sys
 import traceback
+import hy
 
 from hy.version import __version__ as hy_version
 from hy.macros import load_macros
@@ -100,7 +101,6 @@ class CalystoHy(MetaKernel):
         '''
         Create the hy environment
         '''
-        import hy
         self.env = {}
         super(CalystoHy, self).__init__(*args, **kwargs)
         [load_macros(m) for m in [hy.core, hy.macros]]
@@ -133,10 +133,7 @@ class CalystoHy(MetaKernel):
         #### try to parse it:
         try:
             tokens = tokenize(code)
-            _ast = hy_compile(tokens, '', root=ast.Interactive)
-            code = compile(_ast, "In [%s]" % self.execution_count, mode="single")
-            # calls sys.displayhook:
-            eval(code, self.env)
+            self.result = hy.eval(tokens, locals=self.env)
         except Exception as e:
             self.Error(traceback.format_exc())
             self.kernel_resp.update({

--- a/calysto_hy/kernel.py
+++ b/calysto_hy/kernel.py
@@ -10,12 +10,9 @@ import sys
 import traceback
 import hy
 
-from hy.version import __version__ as hy_version
 from hy.macros import load_macros
-from hy import macros as _hy_macros
 from hy.lex import tokenize
 from hy.compiler import hy_compile
-from hy.core import language
 from metakernel import MetaKernel
 
 from .version import __version__
@@ -73,7 +70,7 @@ class CalystoHy(MetaKernel):
     implementation = 'hy'
     implementation_version = __version__
     language = 'hy'
-    language_version = hy_version
+    language_version = hy.version
     banner = 'Hy is a wonderful dialect of Lisp that’s embedded in Python.'
     language_info = {
         'name': 'hy',

--- a/calysto_hy/kernel.py
+++ b/calysto_hy/kernel.py
@@ -10,7 +10,8 @@ import sys
 import traceback
 
 from hy.version import __version__ as hy_version
-from hy.macros import _hy_macros, load_macros
+from hy.macros import load_macros
+from hy import macros as _hy_macros
 from hy.lex import tokenize
 from hy.compiler import hy_compile
 from hy.core import language
@@ -99,9 +100,10 @@ class CalystoHy(MetaKernel):
         '''
         Create the hy environment
         '''
+        import hy
         self.env = {}
         super(CalystoHy, self).__init__(*args, **kwargs)
-        [load_macros(m) for m in ['hy.core', 'hy.macros']]
+        [load_macros(m) for m in [hy.core, hy.macros]]
         if "str" in dir(__builtins__):
             self.env.update({key: getattr(__builtins__, key)
                              for key in dir(__builtins__)})

--- a/notebooks/Hylang Test.ipynb
+++ b/notebooks/Hylang Test.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:44:25.416746",
@@ -37,7 +37,7 @@
        "[None]"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,9 +130,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "What is your name? hello\n",
-      "What is your age? 12\n",
-      "Hello hello!  I see you are 12 years old.\n"
+      "What is your name? Hy Language\n",
+      "What is your age? 2020\n",
+      "Hello Hy Language!  I see you are 2020 years old.\n"
      ]
     },
     {
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:44:57.292469",
@@ -246,7 +246,7 @@
        "[None]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -259,11 +259,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:44:58.030079",
      "start_time": "2016-09-20T22:44:58.023981"
+    },
+    "run_control": {
+     "frozen": false,
+     "read_only": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "That variable is jussssst right!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[None, None]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(setv somevar 33)\n",
+    "(cond\n",
+    " [(> somevar 50)\n",
+    "  (print \"That variable is too big!\")]\n",
+    " [(< somevar 10)\n",
+    "  (print \"That variable is too small!\")]\n",
+    " [True\n",
+    "  (print \"That variable is jussssst right!\")])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2016-09-20T22:44:58.725717",
+     "start_time": "2016-09-20T22:44:58.719791"
     },
     "run_control": {
      "frozen": false,
@@ -292,49 +335,6 @@
    "source": [
     "(setv somevar 33)\n",
     "(cond\n",
-    " [(> somevar 50)\n",
-    "  (print \"That variable is too big!\")]\n",
-    " [(< somevar 10)\n",
-    "  (print \"That variable is too small!\")]\n",
-    " [True\n",
-    "  (print \"That variable is jussssst right!\")])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2016-09-20T22:44:58.725717",
-     "start_time": "2016-09-20T22:44:58.719791"
-    },
-    "run_control": {
-     "frozen": false,
-     "read_only": false
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "That variable is jussssst right!\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[None, None]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(setv somevar 33)\n",
-    "(cond\n",
     " [(> somevar 50) (print \"That variable is too big!\")]\n",
     " [(< somevar 10) (print \"That variable is too small!\")]\n",
     " [True (print \"That variable is jussssst right!\")])"
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:45:04.164458",
@@ -368,7 +368,7 @@
        "[None]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:45:05.297364",
@@ -419,7 +419,7 @@
        "[None]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -431,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:45:13.662642",
@@ -456,7 +456,7 @@
        "[6, None]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:45:23.680044",
@@ -495,7 +495,7 @@
        "[None, None]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -509,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:45:24.235706",
@@ -534,7 +534,7 @@
        "[None, None]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -566,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:47:43.255487",
@@ -584,7 +584,7 @@
        "[<class 'tuple'>]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -602,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:47:45.618443",
@@ -621,7 +621,7 @@
        "[[(0, 'A'), (0, 'B'), (0, 'C'), (0, 'D'), (0, 'E'), (0, 'F'), (0, 'G'), (0, 'H'), (1, 'A'), (1, 'B'), (1, 'C'), (1, 'D'), (1, 'E'), (1, 'F'), (1, 'G'), (1, 'H'), (2, 'A'), (2, 'B'), (2, 'C'), (2, 'D'), (2, 'E'), (2, 'F'), (2, 'G'), (2, 'H'), (3, 'A'), (3, 'B'), (3, 'C'), (3, 'D'), (3, 'E'), (3, 'F'), (3, 'G'), (3, 'H'), (4, 'A'), (4, 'B'), (4, 'C'), (4, 'D'), (4, 'E'), (4, 'F'), (4, 'G'), (4, 'H'), (5, 'A'), (5, 'B'), (5, 'C'), (5, 'D'), (5, 'E'), (5, 'F'), (5, 'G'), (5, 'H'), (6, 'A'), (6, 'B'), (6, 'C'), (6, 'D'), (6, 'E'), (6, 'F'), (6, 'G'), (6, 'H'), (7, 'A'), (7, 'B'), (7, 'C'), (7, 'D'), (7, 'E'), (7, 'F'), (7, 'G'), (7, 'H')]]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -643,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:47:48.115009",
@@ -672,7 +672,7 @@
        "[None, None, None, None, None]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -689,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:47:48.689680",
@@ -707,7 +707,7 @@
        "[None, None, [[1, 2], {'keyword2': 3, 'keyword1': 4}, None, 42]]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -720,120 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2016-09-20T22:47:49.189602",
-     "start_time": "2016-09-20T22:47:49.183920"
-    },
-    "run_control": {
-     "frozen": false,
-     "read_only": false
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[0;31mTraceback (most recent call last):\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 121, in parse\n",
-      "    (tree, _) = self.run(tokens, State())\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 158, in _add\n",
-      "    (v2, s3) = other.run(tokens, s2)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 199, in _shift\n",
-      "    (v, s2) = self.run(tokens, s)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 272, in finished\n",
-      "    raise NoParseError('should have reached <EOF>', s)\n",
-      "funcparserlib.parser.NoParseError: should have reached <EOF>\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 121, in parse\n",
-      "    (tree, _) = self.run(tokens, State())\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 157, in _add\n",
-      "    (v1, s2) = self.run(tokens, s)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 157, in _add\n",
-      "    (v1, s2) = self.run(tokens, s)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 200, in _shift\n",
-      "    return f(v), s2\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/model_patterns.py\", line 37, in <lambda>\n",
-      "    (lambda x: group_type(whole(parsers).parse(x)).replace(x, recursive=False)))\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 129, in parse\n",
-      "    raise NoParseError('%s: %s' % (e.msg, tok), e.state)\n",
-      "funcparserlib.parser.NoParseError: should have reached <EOF>: HyDict([\n",
-      "  HyString('key1'), HyString('val1'),\n",
-      "  HyString('key2'), HyString('val2')])\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1580, in compile_expression\n",
-      "    parse_tree = pattern.parse(expression[1:])\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/funcparserlib/parser.py\", line 129, in parse\n",
-      "    raise NoParseError('%s: %s' % (e.msg, tok), e.state)\n",
-      "funcparserlib.parser.NoParseError: should have reached <EOF>: HyDict([\n",
-      "  HyString('key1'), HyString('val1'),\n",
-      "  HyString('key2'), HyString('val2')]): HyList([\n",
-      "  HySymbol('key1'),\n",
-      "  HySymbol('key2')])\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/calysto_hy/kernel.py\", line 134, in do_execute_direct\n",
-      "    _ast = hy_compile(tokens, '', root=ast.Interactive)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1723, in hy_compile\n",
-      "    result = compiler.compile(tree)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 350, in compile\n",
-      "    ret = self.compile_atom(tree)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 344, in compile_atom\n",
-      "    return Result() + _model_compilers[type(atom)](self, atom)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1699, in compile_list\n",
-      "    elts, ret, _ = self._compile_collect(expression)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 423, in _compile_collect\n",
-      "    ret += self.compile(expr)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 350, in compile\n",
-      "    ret = self.compile_atom(tree)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 344, in compile_atom\n",
-      "    return Result() + _model_compilers[type(atom)](self, atom)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1588, in compile_expression\n",
-      "    self, expression, unmangle(sfn), *parse_tree)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1299, in compile_def_expression\n",
-      "    result += self._compile_assign(*pair)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1311, in _compile_assign\n",
-      "    result = self.compile(result)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 350, in compile\n",
-      "    ret = self.compile_atom(tree)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 344, in compile_atom\n",
-      "    return Result() + _model_compilers[type(atom)](self, atom)\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/hy/compiler.py\", line 1586, in compile_expression\n",
-      "    e.msg.replace(\"<EOF>\", \"end of form\")))\n",
-      "hy.errors.HyTypeError:   File \"None\", line 2, column 3\n",
-      "\n",
-      "HyTypeError: parse error for special form 'fn*': should have reached end of form: HyDict([\n",
-      "  HyString('key1'), HyString('val1'),\n",
-      "  HyString('key2'), HyString('val2')]): HyList([\n",
-      "  HySymbol('key1'),\n",
-      "  HySymbol('key2')])\n",
-      "\n",
-      "\n",
-      "\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
-   "source": [
-    "(defn another-style [&key {\"key1\" \"val1\" \"key2\" \"val2\"}]\n",
-    "  [key1 key2])\n",
-    "(setv kwargs {\"key1\" 1 \"key2\" 2})\n",
-    "(another-style kwargs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:47:55.643519",
@@ -852,7 +739,7 @@
        "['3']"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -877,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:48:00.615212",
@@ -890,81 +777,29 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[0;31mTraceback (most recent call last):\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/calysto_hy/kernel.py\", line 137, in do_execute_direct\n",
-      "    eval(code, self.env)\n",
-      "  File \"In [42]\", line 1, in <module>\n",
-      "  File \"In [42]\", line 3, in FooBar\n",
-      "NameError: name '__init__' is not defined\n",
-      "\n",
-      "\u001b[0m"
-     ]
+     "data": {
+      "text/plain": [
+       "[None]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "(defclass FooBar [object]\n",
-    "  \"Yet Another Example Class\"\n",
-    "  [[--init--\n",
-    "    (fn [self x]\n",
-    "      (setv self.x x)\n",
-    "      ; Currently needed for --init-- because __init__ needs None\n",
-    "      ; Hopefully this will go away :)\n",
-    "      None)]\n",
-    "   [get-x\n",
-    "    (fn [self]\n",
-    "      \"Return our copy of x\"\n",
-    "      self.x)]])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A class with class variables."
+    "(defclass FooBar []\n",
+    "        \"Yet Another Example Class\"\n",
+    "  (defn __init__ [self x]\n",
+    "    (setv self.x x))\n",
+    "  (defn get-x [self]\n",
+    "        \"Return our copy of x\"\n",
+    "    self.x))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2016-09-20T22:48:02.266067",
-     "start_time": "2016-09-20T22:48:02.260581"
-    },
-    "run_control": {
-     "frozen": false,
-     "read_only": false
-    },
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[0;31mTraceback (most recent call last):\n",
-      "  File \"/home/dblank/.local/lib/python3.6/site-packages/calysto_hy/kernel.py\", line 137, in do_execute_direct\n",
-      "    eval(code, self.env)\n",
-      "  File \"In [43]\", line 1, in <module>\n",
-      "NameError: name 'models' is not defined\n",
-      "\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
-   "source": [
-    "(defclass Customer [models.Model]\n",
-    "  [[name (models.CharField :max-length 255)]\n",
-    "   [address (models.TextField)]\n",
-    "   [notes (models.TextField)]])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2016-09-20T22:48:04.500362",
@@ -980,17 +815,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "hello\n",
-      "jello\n"
+      "hello!\n",
+      "bye!\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['hello', 'jello']"
+       "['hello!', 'bye!']"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1000,15 +835,6 @@
     "(->> (str) (input))  ; execution from right (outer) to left (inner)\n",
     ";"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This change updates the macro path so that it finds the macros on the newer version of Hy (0.18.0), fixing issue #15 . I really didn't get the change in load_macros but it apparently loads ok.

I also managed to get it working and evaluating, but it didn't pass some of the tests. I wonder whether the tests are outdated also (todo). There is also probably the need to clean some unused imports after the changes. 