### PR TITLE
Import __version__ from hy rather than from hy.version.

### DIFF
--- a/calysto_hy/kernel.py
+++ b/calysto_hy/kernel.py
@@ -15,7 +15,7 @@ import hy.core
 import hy.macros
 import hy.reader
 
-from hy.version import __version__ as hy_version
+from hy import __version__ as hy_version
 from hy.compiler import hy_compile, HyASTCompiler
 from metakernel import MetaKernel
 


### PR DESCRIPTION
Installing the Calysto Hy kernel currently breaks with the following error message:

```
$ python -m calysto_hy install
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/home/scolobb/Candies/prj/hy/hy-venv/lib/python3.12/site-packages/calysto_hy/__init__.py", line 2, in <module>
    from .kernel import CalystoHy
  File "/home/scolobb/Candies/prj/hy/hy-venv/lib/python3.12/site-packages/calysto_hy/kernel.py", line 18, in <module>
    from hy.version import __version__ as hy_version
ModuleNotFoundError: No module named 'hy.version'
```

This PR fixes the error for me and I can successfully install the Calysto Hy kernel.